### PR TITLE
fix: make android opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ Subcommands:
   help: Print this help message.
 
 Options:
+  --android: Generate or check a lockfile for Android (opt-in).
   --non-interactive: Skip interactive prompts (assumes 'yes').
   --debug: Print debug information.
 ```
@@ -62,14 +63,19 @@ The above may be desirable if you're OK with the risk that the underlying depend
 
 It can also be good to have visibility into the state of native dependencies for security scanning or supply chain management (SAST scans). With the recommended approach of ignoring the native project folders under CNG, you have no visibility into what dependencies your yarn lockfile-defined dependencies are pulling in.
 
+## A note on gradle.lockfile
+
+React Native dependencies on Android aren't really dependencies but instead are "sub projects" that are included into the main "app" project. This structure is termed a Composite Build. Gradle's locking mechanism does not support composite builds out of the box. More work on this to follow.
+
 ## Roadmap to v1
 
 Things to iron out:
 
 - [x] get full scenario CI test workflow passing (issue w/ plugin always writing?)
-- [ ] make android opt-in for now (composite builds aren't covered by "app" lockfile so it's a partial picture)
+- [x] make android opt-in for now (composite builds aren't covered by "app" lockfile so it's a partial picture)
 - [ ] make xcode version (and others?) clearer and configurable
 - [ ] allow for running for a specific platform
 - [ ] provide better API or guidance for upgrade path (Expo / React Native bumps)
 - [ ] figure out how to speed up the gradle lockfile write (--offline w/ cache?)
 - [ ] add a simple readme example for CI check config
+- [ ] merging gradle lockfiles of all composite build projects beyond just "app"

--- a/cli/src/checker.ts
+++ b/cli/src/checker.ts
@@ -3,9 +3,9 @@ import { existsSync } from "fs";
 import { readFile, writeFile } from "fs/promises";
 import { $, shasumHash } from "./utils";
 
-export const precheck = () => {
+export const precheck = ({ android }: { android?: boolean }) => {
   const basePodfileExists = existsSync("Podfile.lock");
-  const baseGradleLockExists = existsSync("gradle.lockfile");
+  const baseGradleLockExists = android ? existsSync("gradle.lockfile") : true;
   if (!basePodfileExists || !baseGradleLockExists) {
     console.warn(
       "Base lockfiles do not exist at Podfile.lock or gradle.lockfile. Run `yarn native-lock` to generate them before running with --check."

--- a/cli/src/checker.ts
+++ b/cli/src/checker.ts
@@ -35,20 +35,24 @@ const getPodLockfileStableChecksum = async (project: string = ".") => {
 
 export const checkLockfilesAndExit = async ({
   debug,
+  android,
   project,
 }: {
   debug?: boolean;
+  android?: boolean;
   project: string;
 }) => {
   const basePodfileChecksum = shasumHash(await getPodLockfileStableChecksum());
-  const baseGradleChecksum = shasumHash(await $`shasum gradle.lockfile`);
-
   const podfileChecksum = shasumHash(
     await getPodLockfileStableChecksum(project)
   );
-  const gradleChecksum = shasumHash(
-    await $`shasum android/app/gradle.lockfile`
-  );
+
+  let baseGradleChecksum = "";
+  let gradleChecksum = "";
+  if (android) {
+    baseGradleChecksum = shasumHash(await $`shasum gradle.lockfile`);
+    gradleChecksum = shasumHash(await $`shasum android/app/gradle.lockfile`);
+  }
 
   const podfileChecksumMatch = podfileChecksum === basePodfileChecksum;
   const gradleChecksumMatch = gradleChecksum === baseGradleChecksum;
@@ -56,8 +60,10 @@ export const checkLockfilesAndExit = async ({
   if (debug) {
     console.log("New Podfile.lock checksum:", podfileChecksum);
     console.log("Old Podfile.lock checksum:", basePodfileChecksum);
-    console.log("New gradle.lockfile checksum:", gradleChecksum);
-    console.log("Old gradle.lockfile checksum:", baseGradleChecksum);
+    if (android) {
+      console.log("New gradle.lockfile checksum:", gradleChecksum);
+      console.log("Old gradle.lockfile checksum:", baseGradleChecksum);
+    }
     console.log({ podfileChecksumMatch, gradleChecksumMatch });
   }
 

--- a/cli/src/main.ts
+++ b/cli/src/main.ts
@@ -78,7 +78,7 @@ const expoPrebuildCommand = "expo prebuild --clean --no-install";
 
 const run = async () => {
   if (checkMode) {
-    precheck();
+    precheck({ android });
   }
 
   if (nonInteractive === false) {

--- a/plugin/src/lockfile-plugin.ts
+++ b/plugin/src/lockfile-plugin.ts
@@ -81,13 +81,28 @@ const withPodsLockfile: ConfigPlugin = (config) => {
   ]);
 };
 
-const withLockfilePlugin: ConfigPlugin = (config) => {
+type PluginProps =
+  | {
+      android?: boolean;
+    }
+  | undefined;
+
+const withLockfilePlugin: ConfigPlugin<PluginProps> = (config, props) => {
   if (!generating) {
     WarningAggregator.addWarningIOS(
       pluginTag,
       "Lockfiles are not being generated (running in check mode)."
     );
+
+    if (!props?.android) {
+      return config;
+    }
+
     return withGradleLockfileActivated(config);
+  }
+
+  if (!props?.android) {
+    return withPodsLockfile(config);
   }
 
   return withGradleLockfileActivated(


### PR DESCRIPTION
As noted in the readme change, to make gradle lockfiles useful for a react native project, more work needs to be done to cover the sub projects brought in via autolinking.

More reading on gradle topics:

* https://docs.gradle.org/current/userguide/dependency_locking.html
* https://github.com/gradle/gradle/issues/4749
* https://docs.gradle.org/current/userguide/composite_builds.html